### PR TITLE
Extend Gremlin Driver Authentication

### DIFF
--- a/chaosgremlin/__init__.py
+++ b/chaosgremlin/__init__.py
@@ -8,7 +8,6 @@ __all__ = ["__version__", "GREMLIN_BASE_URL", "auth"]
 __version__ = '0.3.0'
 GREMLIN_BASE_URL = "https://api.gremlin.com/v1"
 
-
 def auth(email: str, password: str, org_name: str):
     """
     Private function that authorizes against the Gremlin API.
@@ -32,3 +31,9 @@ def auth(email: str, password: str, org_name: str):
                 u=email, o=org_name))
 
     return session
+
+def auth(api_key: str):
+    """
+    Private function that returns mock session containing only an API Key.
+    """
+    return {'header': f'Key {api_key}'}

--- a/chaosgremlin/actions.py
+++ b/chaosgremlin/actions.py
@@ -34,7 +34,7 @@ def attack(command: Dict[str, Any], target: Dict[str, Any],
     if secrets is not None:
         session = auth(**secrets)
     else:
-        session = auth(api_key) 
+        session = auth(os.environ.get('GREMLIN_API_KEY'))   # Your API Key should be declared as an environment variable  
 
     url = "{base}/attacks/new".format(base=GREMLIN_BASE_URL)
     r = requests.post(

--- a/chaosgremlin/actions.py
+++ b/chaosgremlin/actions.py
@@ -18,9 +18,9 @@ __all__ = ["attack"]
 
 def attack(command: Dict[str, Any], target: Dict[str, Any],
            labels: Dict[str, Any] = None, tags: Dict[str, Any] = None,
-           secrets: Secrets = None):
+           secrets: Secrets = None, api_key: str = None):
     """
-    Triggers an attack on the CPU of a host. Please refer to Gremlin's
+    Send attack declaration (JSON) to Gremlin API for execution. Please refer to Gremlin's
     documentation for the meaning of each argument. The `secrets` argument is
     a mapping which must have the following keys: `email`, `password` and
     `org_name`.
@@ -31,7 +31,10 @@ def attack(command: Dict[str, Any], target: Dict[str, Any],
 
     .. seealso:: https://www.gremlin.com/docs/
     """
-    session = auth(**secrets)
+    if secrets is not None:
+        session = auth(**secrets)
+    else:
+        session = auth(api_key) 
 
     url = "{base}/attacks/new".format(base=GREMLIN_BASE_URL)
     r = requests.post(
@@ -51,6 +54,6 @@ def attack(command: Dict[str, Any], target: Dict[str, Any],
             "Gremlin attack failed: {m}".format(m=r.text))
 
     result = r.text
-    logger.debug("attack submitted succesfully: {r}".format(r=result))
+    logger.debug("attack submitted successfully: {r}".format(r=result))
 
     return result


### PR DESCRIPTION
Extended the Gremlin driver to accept the API Key as an alternative method of authentication.